### PR TITLE
chore: ignore generated dependency directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Ignore Node modules and build output
+codexhorary/frontend/node_modules/
+codexhorary/frontend/dist/
+codexhorary/frontend/dist-electron/
+
+# Ignore backend build artifacts
+codexhorary/backend/build/
+codexhorary/backend/dist/
+
+# Python cache and logs
+__pycache__/
+*.pyc
+*.log
+.env


### PR DESCRIPTION
## Summary
- avoid tracking generated frontend and backend build directories
- ignore Python caches, logs and env files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c24ba940832485aa926c8b60fd6e